### PR TITLE
patched bug in setBit

### DIFF
--- a/src/bit_maths.hpp
+++ b/src/bit_maths.hpp
@@ -60,9 +60,10 @@ INLINE Index insertBits(Index number, NatArray bitIndices, Nat bitValue) {
 
 
 INLINE Index setBit(Index number, Nat bitIndex, Nat bitValue) {
-    
+
+    Index comp = ~ (1ULL << bitIndex);
     Index mask = bitValue << bitIndex;
-    return (number & (~mask)) | mask;
+    return (number & (~comp)) | mask;
 }
 
 


### PR DESCRIPTION
which miraculously causes no errors for the inputs given during its invocation by the algorithms. But it's worthwhile to make it valid for general inputs, to avoid user confusion